### PR TITLE
Use only the domain-scan requirements needed for Lambda invocation

### DIFF
--- a/pshtt/build_pshtt.sh
+++ b/pshtt/build_pshtt.sh
@@ -16,7 +16,7 @@ pip install --upgrade pip setuptools
 # Install domain-scan
 ###
 git clone https://github.com/18F/domain-scan
-pip install --upgrade -r domain-scan/requirements.txt
+pip install --upgrade -r domain-scan/lambda/requirements-lambda.txt
 
 ##
 # Force pip to install the latest pshtt from GitHub.

--- a/sslyze/build_sslyze.sh
+++ b/sslyze/build_sslyze.sh
@@ -21,7 +21,7 @@ pip install --upgrade sslyze==1.3.4
 # Install domain-scan
 ###
 git clone https://github.com/18F/domain-scan
-pip install --upgrade -r domain-scan/requirements.txt
+pip install --upgrade -r domain-scan/lambda/requirements-lambda.txt
 
 ###
 # Leave the Python virtual environment

--- a/trustymail/build_trustymail.sh
+++ b/trustymail/build_trustymail.sh
@@ -22,7 +22,7 @@ pip install --upgrade \
 # Install domain-scan
 ###
 git clone https://github.com/18F/domain-scan
-pip install --upgrade -r domain-scan/requirements.txt
+pip install --upgrade -r domain-scan/lambda/requirements-lambda.txt
 
 ###
 # Leave the Python virtual environment


### PR DESCRIPTION
This PR adapts to what I added to https://github.com/18F/domain-scan/pull/224, which makes a new `lambda/requirements-lambda.txt` file that contains only the dependencies needed during (Python-based) Lambda function invocation.

I have not tested it locally yet, and it shouldn't be tested and merged until https://github.com/18F/domain-scan/pull/224 is merged.