### PR TITLE
Use the latest version of trustymail

### DIFF
--- a/trustymail/build_trustymail.sh
+++ b/trustymail/build_trustymail.sh
@@ -15,7 +15,7 @@ pip install --upgrade pip setuptools
 ##
 # Install trustymail
 ##
-pip install --upgrade trustymail==0.6.4
+pip install --upgrade trustymail==0.6.5
 
 ###
 # Install domain-scan


### PR DESCRIPTION
The latest version of trustymail moves the warning message generated when a domain's DMARC record lists more than two `rua` or `ruf` URIs to the `debug_error` field.  This is useful because having a warning message in the `syntax_error` field is confusing to some report recipients.