### PR TITLE
Turn off nounset before running activate

### DIFF
--- a/pshtt/build_pshtt.sh
+++ b/pshtt/build_pshtt.sh
@@ -9,12 +9,18 @@ set -o pipefail
 ###
 VENV_DIR=/venv
 python -m venv $VENV_DIR
-# Here shellcheck complains because it can't follow the dynamic path.
-# The path doesn't even exist until runtime, so we must disable that
-# check.
+# Note that we have to turn off nounset before running activate, since
+# otherwise we can get an error that states "/venv/bin/activate: line
+# 6: _OLD_VIRTUAL_PATH: unbound variable".  See
+# cisagov/lambda_functions#29 for more details.
+set +o nounset
+# Note also that shellcheck complains because it can't follow the
+# dynamic path.  The path doesn't even exist until runtime, so we must
+# disable that check.
 #
 # shellcheck disable=1090
 source $VENV_DIR/bin/activate
+set -o nounset
 
 ###
 # Update pip and setuptools

--- a/sslyze/build_sslyze.sh
+++ b/sslyze/build_sslyze.sh
@@ -9,12 +9,18 @@ set -o pipefail
 ###
 VENV_DIR=/venv
 python -m venv $VENV_DIR
-# Here shellcheck complains because it can't follow the dynamic path.
-# The path doesn't even exist until runtime, so we must disable that
-# check.
+# Note that we have to turn off nounset before running activate, since
+# otherwise we can get an error that states "/venv/bin/activate: line
+# 6: _OLD_VIRTUAL_PATH: unbound variable".  See
+# cisagov/lambda_functions#29 for more details.
+set +o nounset
+# Note also that shellcheck complains because it can't follow the
+# dynamic path.  The path doesn't even exist until runtime, so we must
+# disable that check.
 #
 # shellcheck disable=1090
 source $VENV_DIR/bin/activate
+set -o nounset
 
 ###
 # Update pip and setuptools

--- a/trustymail/build_trustymail.sh
+++ b/trustymail/build_trustymail.sh
@@ -9,12 +9,18 @@ set -o pipefail
 ###
 VENV_DIR=/venv
 python -m venv $VENV_DIR
-# Here shellcheck complains because it can't follow the dynamic path.
-# The path doesn't even exist until runtime, so we must disable that
-# check.
+# Note that we have to turn off nounset before running activate, since
+# otherwise we can get an error that states "/venv/bin/activate: line
+# 6: _OLD_VIRTUAL_PATH: unbound variable".  See
+# cisagov/lambda_functions#29 for more details.
+set +o nounset
+# Note also that shellcheck complains because it can't follow the
+# dynamic path.  The path doesn't even exist until runtime, so we must
+# disable that check.
 #
 # shellcheck disable=1090
 source $VENV_DIR/bin/activate
+set -o nounset
 
 ###
 # Update pip and setuptools


### PR DESCRIPTION
It is causing the activate script to error out for some folks.  This pull request resolves #29.

Thanks to @refayathaque for providing some screenshots that allowed me to see what was going on.