### PR TITLE
Use the official Lambda Docker images from AWS

### DIFF
--- a/pshtt/Dockerfile
+++ b/pshtt/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-python3.7
+FROM public.ecr.aws/lambda/python:3.7
 MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
 
 # We need wget to download the public suffix list

--- a/pshtt/Dockerfile
+++ b/pshtt/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/lambda/python:3.7
-MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
+MAINTAINER Shane Frasier <jeremy.frasier@gwe.cisa.dhs.gov>
 
 # We need to install some basic packages so that the Docker container
 # can run the build_pshtt.sh script.

--- a/pshtt/Dockerfile
+++ b/pshtt/Dockerfile
@@ -1,8 +1,11 @@
 FROM public.ecr.aws/lambda/python:3.7
 MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
 
-# We need wget to download the public suffix list
-RUN yum -q -y install wget
+# We need to install some basic packages so that the Docker container
+# can run the build_pshtt.sh script.
+RUN yum -q -y install \
+    wget \
+    zip
 
 COPY build_pshtt.sh .
 

--- a/pshtt/build_pshtt.sh
+++ b/pshtt/build_pshtt.sh
@@ -8,7 +8,7 @@ set -o pipefail
 # Set up the Python virtual environment
 ###
 VENV_DIR=/venv
-python -m venv $VENV_DIR
+python3 -m venv $VENV_DIR
 # Note that we have to turn off nounset before running activate, since
 # otherwise we can get an error that states "/venv/bin/activate: line
 # 6: _OLD_VIRTUAL_PATH: unbound variable".  See
@@ -25,19 +25,19 @@ set -o nounset
 ###
 # Update pip, setuptools, and wheel
 ###
-pip install --upgrade pip setuptools wheel
+pip3 install --upgrade pip setuptools wheel
 
 ##
 # Install pshtt
 ##
-pip install --upgrade pshtt==0.6.10
+pip3 install --upgrade pshtt==0.6.10
 
 ###
 # Install domain-scan
 ###
 [ -d domain-scan ] || mkdir domain-scan
 wget -q -O - https://api.github.com/repos/cisagov/domain-scan/tarball | tar xz --strip-components=1 -C domain-scan
-pip install --upgrade -r domain-scan/lambda/requirements-lambda.txt
+pip3 install --upgrade -r domain-scan/lambda/requirements-lambda.txt
 
 ###
 # Leave the Python virtual environment

--- a/sslyze/Dockerfile
+++ b/sslyze/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-python3.7
+FROM public.ecr.aws/lambda/python:3.7
 MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
 
 # We need wget to download the public suffix list

--- a/sslyze/Dockerfile
+++ b/sslyze/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/lambda/python:3.7
-MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
+MAINTAINER Shane Frasier <jeremy.frasier@gwe.cisa.dhs.gov>
 
 # We need to install some basic packages so that the Docker container
 # can run the build_sslyze.sh script.

--- a/sslyze/Dockerfile
+++ b/sslyze/Dockerfile
@@ -1,8 +1,11 @@
 FROM public.ecr.aws/lambda/python:3.7
 MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
 
-# We need wget to download the public suffix list
-RUN yum -q -y install wget
+# We need to install some basic packages so that the Docker container
+# can run the build_sslyze.sh script.
+RUN yum -q -y install \
+    wget \
+    zip
 
 COPY build_sslyze.sh .
 

--- a/sslyze/build_sslyze.sh
+++ b/sslyze/build_sslyze.sh
@@ -8,7 +8,7 @@ set -o pipefail
 # Set up the Python virtual environment
 ###
 VENV_DIR=/venv
-python -m venv $VENV_DIR
+python3 -m venv $VENV_DIR
 # Note that we have to turn off nounset before running activate, since
 # otherwise we can get an error that states "/venv/bin/activate: line
 # 6: _OLD_VIRTUAL_PATH: unbound variable".  See
@@ -25,19 +25,19 @@ set -o nounset
 ###
 # Update pip, setuptools, and wheel
 ###
-pip install --upgrade pip setuptools wheel
+pip3 install --upgrade pip setuptools wheel
 
 ###
 # Install sslyze
 ###
-pip install --upgrade sslyze==2.1.4
+pip3 install --upgrade sslyze==2.1.4
 
 ###
 # Install domain-scan
 ###
 [ -d domain-scan ] || mkdir domain-scan
 wget -q -O - https://api.github.com/repos/cisagov/domain-scan/tarball | tar xz --strip-components=1 -C domain-scan
-pip install --upgrade -r domain-scan/lambda/requirements-lambda.txt
+pip3 install --upgrade -r domain-scan/lambda/requirements-lambda.txt
 
 ###
 # Leave the Python virtual environment

--- a/trustymail/Dockerfile
+++ b/trustymail/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-python3.7
+FROM public.ecr.aws/lambda/python:3.7
 MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
 
 # We need wget to download the public suffix list

--- a/trustymail/Dockerfile
+++ b/trustymail/Dockerfile
@@ -1,8 +1,11 @@
 FROM public.ecr.aws/lambda/python:3.7
 MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
 
-# We need wget to download the public suffix list
-RUN yum -q -y install wget
+# We need to install some basic packages so that the Docker container
+# can run the build_trustymail.sh script.
+RUN yum -q -y install \
+    wget \
+    zip
 
 COPY build_trustymail.sh .
 

--- a/trustymail/Dockerfile
+++ b/trustymail/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/lambda/python:3.7
-MAINTAINER Shane Frasier <jeremy.frasier@trio.dhs.gov>
+MAINTAINER Shane Frasier <jeremy.frasier@gwe.cisa.dhs.gov>
 
 # We need to install some basic packages so that the Docker container
 # can run the build_trustymail.sh script.

--- a/trustymail/build_trustymail.sh
+++ b/trustymail/build_trustymail.sh
@@ -8,7 +8,7 @@ set -o pipefail
 # Set up the Python virtual environment
 ###
 VENV_DIR=/venv
-python -m venv $VENV_DIR
+python3 -m venv $VENV_DIR
 # Note that we have to turn off nounset before running activate, since
 # otherwise we can get an error that states "/venv/bin/activate: line
 # 6: _OLD_VIRTUAL_PATH: unbound variable".  See
@@ -25,19 +25,19 @@ set -o nounset
 ###
 # Update pip, setuptools, and wheel
 ###
-pip install --upgrade pip setuptools wheel
+pip3 install --upgrade pip setuptools wheel
 
 ##
 # Install trustymail
 ##
-pip install --upgrade trustymail==0.8.1
+pip3 install --upgrade trustymail==0.8.1
 
 ###
 # Install domain-scan
 ###
 [ -d domain-scan ] || mkdir domain-scan
 wget -q -O - https://api.github.com/repos/cisagov/domain-scan/tarball | tar xz --strip-components=1 -C domain-scan
-pip install --upgrade -r domain-scan/lambda/requirements-lambda.txt
+pip3 install --upgrade -r domain-scan/lambda/requirements-lambda.txt
 
 ###
 # Leave the Python virtual environment


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the repo to use [the official Lambda Docker images from AWS](https://docs.aws.amazon.com/lambda/latest/dg/python-image.html#python-image-base).

## 💭 Motivation and context ##

In addition to it just being a better idea in general to use the official images from AWS, the official images are still being updated.  The `lambci/lambda` Docker images we were using have not been updated in years.

## 🧪 Testing ##

I deployed new Lambda functions built using these changes and verified that they function as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.

## ✅ Post-merge checklist ##

- [ ] Create a release.
